### PR TITLE
updated sidekiq to version 6.5.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM getlago/api:v1.8.2 as build
 
-RUN bundle remove sidekiq && bundle add sidekiq --version "~> 6"
+RUN bundle remove sidekiq && bundle add sidekiq --version "~> 6.5.12"
 
 FROM getlago/api:v1.8.2
 


### PR DESCRIPTION
updated sidekiq to version 6.5.12 to eleviate an error that was occuring in the newer versions of the ActiveSupport gem of the lago project.

Lets wait to merge this until we 100% know everything works like we want to. for example the applied taxes field in the fee object that is not there.